### PR TITLE
Update Facebook Login Kit lib version

### DIFF
--- a/LoginRadiusSDK.podspec
+++ b/LoginRadiusSDK.podspec
@@ -26,7 +26,7 @@ s.source       = { :git => 'https://github.com/LoginRadius/ios-sdk.git', :tag =>
 
 s.source_files = ['Sources/**/*.{h,m}']
 
-s.dependency 'FBSDKLoginKit', '~> 9.0'
+s.dependency 'FBSDKLoginKit', '~> 11.0'
 s.dependency 'SimpleKeychain', '~> 0.7.0'
 
 s.ios.frameworks = 'Foundation', 'UIKit', 'SystemConfiguration', 'Social', 'Accounts', 'SafariServices'


### PR DESCRIPTION
FacebookLoginKit have some trouble to compile on last XCode version (13.x). 
Version 11.0 have been tested and approved for this XCode version.

Could you please integrate this change in your podspec ?